### PR TITLE
Fix rendering of WebDocuments

### DIFF
--- a/jodconverter-core/src/main/java/org/artofsolving/jodconverter/OfficeDocumentUtils.java
+++ b/jodconverter-core/src/main/java/org/artofsolving/jodconverter/OfficeDocumentUtils.java
@@ -29,7 +29,11 @@ class OfficeDocumentUtils {
 
     public static DocumentFamily getDocumentFamily(XComponent document) throws OfficeException {
         XServiceInfo serviceInfo = cast(XServiceInfo.class, document);
-        if (serviceInfo.supportsService("com.sun.star.text.GenericTextDocument")) {
+        if (serviceInfo.supportsService("com.sun.star.text.WebDocument")) {
+            // if the document is identified as a WebDocument then the web PDF export filter must be used.
+            // otherwise error 2074 will occur.
+            return DocumentFamily.TEXT_WEB;
+        } else if (serviceInfo.supportsService("com.sun.star.text.GenericTextDocument")) {
             // NOTE: a GenericTextDocument is either a TextDocument, a WebDocument, or a GlobalDocument
             // but this further distinction doesn't seem to matter for conversions
             return DocumentFamily.TEXT;

--- a/jodconverter-core/src/main/java/org/artofsolving/jodconverter/document/DefaultDocumentFormatRegistry.java
+++ b/jodconverter-core/src/main/java/org/artofsolving/jodconverter/document/DefaultDocumentFormatRegistry.java
@@ -24,6 +24,7 @@ public class DefaultDocumentFormatRegistry extends SimpleDocumentFormatRegistry 
 		pdf.setStoreProperties(DocumentFamily.SPREADSHEET, Collections.singletonMap("FilterName", "calc_pdf_Export"));
 		pdf.setStoreProperties(DocumentFamily.PRESENTATION, Collections.singletonMap("FilterName", "impress_pdf_Export"));
 		pdf.setStoreProperties(DocumentFamily.DRAWING, Collections.singletonMap("FilterName", "draw_pdf_Export"));
+		pdf.setStoreProperties(DocumentFamily.TEXT_WEB, Collections.singletonMap("FilterName", "writer_web_pdf_Export"));
 		addFormat(pdf);
 		
 		DocumentFormat swf = new DocumentFormat("Macromedia Flash", "swf", "application/x-shockwave-flash");

--- a/jodconverter-core/src/main/java/org/artofsolving/jodconverter/document/DocumentFamily.java
+++ b/jodconverter-core/src/main/java/org/artofsolving/jodconverter/document/DocumentFamily.java
@@ -14,6 +14,6 @@ package org.artofsolving.jodconverter.document;
 
 public enum DocumentFamily {
 
-    TEXT, SPREADSHEET, PRESENTATION, DRAWING
+    TEXT, SPREADSHEET, PRESENTATION, DRAWING, TEXT_WEB
 
 }


### PR DESCRIPTION
When generating a PDF from a WebDocument  (doc or docx generated from
webpage) error 4027 occurs. Added new DocumentFamily.TEXT_WEB to resolve
this.
