### PR TITLE
Compatible with latest OpenOffice on MacOS

### DIFF
--- a/jodconverter-core/src/main/java/org/artofsolving/jodconverter/office/OfficeUtils.java
+++ b/jodconverter-core/src/main/java/org/artofsolving/jodconverter/office/OfficeUtils.java
@@ -77,7 +77,8 @@ public class OfficeUtils {
         } else if (PlatformUtils.isMac()) {
             return findOfficeHome(
                 "/Applications/OpenOffice.org.app/Contents",
-                "/Applications/LibreOffice.app/Contents"
+                "/Applications/LibreOffice.app/Contents",
+                "/Applications/OpenOffice.app/Contents"
             );
         } else {
             // Linux or other *nix variants


### PR DESCRIPTION
fix bug on MacOS:
```
Failed tests: 
  runAllPossibleConversions(org.artofsolving.jodconverter.OfficeDocumentConverterFunctionalTest): officeHome not set and could not be auto-detected
  executeTask(org.artofsolving.jodconverter.office.ExternalOfficeManagerTest): Cannot run program "/Users/chengke/Workspace/opensource/jodconverter_git/jodconverter-core/MacOS/soffice.bin": error=2, No such file or directory
  executeTask(org.artofsolving.jodconverter.office.PooledOfficeManagerTest): failed to start and connect
  restartAfterCrash(org.artofsolving.jodconverter.office.PooledOfficeManagerTest): failed to start and connect
  restartAfterTaskTimeout(org.artofsolving.jodconverter.office.PooledOfficeManagerTest): failed to start and connect
  restartWhenMaxTasksPerProcessReached(org.artofsolving.jodconverter.office.PooledOfficeManagerTest): failed to start and connect
```